### PR TITLE
Use a string when defining constants to prevent php notices.

### DIFF
--- a/init.php
+++ b/init.php
@@ -54,7 +54,7 @@ class cmb_Meta_Box_Validate {
 
 
 /*
- * Script url to load local resources.
+ * url to load local resources.
  */
 
 define( 'CMB_META_BOX_URL', trailingslashit( str_replace( WP_CONTENT_DIR, WP_CONTENT_URL, dirname(__FILE__) ) ) );


### PR DESCRIPTION
A correction to my previously submitted pull request.
