### PR TITLE
Add a cmb_meta_box filter

### DIFF
--- a/init.php
+++ b/init.php
@@ -31,7 +31,7 @@ Version: 		0.5
 /************************************************************************
 		You should not edit the code below or things might explode!
 *************************************************************************/
-
+$meta_boxes = apply_filters ( 'cmb_meta_boxes' , $meta_boxes );
 foreach ( $meta_boxes as $meta_box ) {
 	$my_box = new cmb_Meta_Box( $meta_box );
 }


### PR DESCRIPTION
This one line of code will allow developers to use custom meta boxes in a theme _and_ a plugin simultaneously. It should not affect anyone already using it in their theme.

My main use case for this: distributing a plugin with the custom meta boxes library in it to someone else who might already be using the library. In that case, the plugin could add meta boxes to the main $meta_box library using a filter, which would then get added to the $meta_boxes array before the meta boxes are rendered. My plugin could contain code like this:

<pre>
add_filter('cmb_meta_boxes', 'rrh_meta_boxes');
function rrh_meta_boxes($meta_boxes) {

    $meta_boxes[] = array(
        'id' => 'rrh_info',
        'title' => 'RRH Info',
        'pages' => array('rrh_post_type'), // post type
        'context' => 'normal',
        'priority' => 'low',
        'show_names' => true, // Show field names left of input
        'fields' => array(
            array(
                'name' => 'Phone',
                'id' => 'rrh_phone',
                'type' => 'text'
            ),
                                                
        ),
    );
    return $meta_boxes;

}

add_action('init','mythsoc_initialize_cmb_meta_boxes',9999);
function mythsoc_initialize_cmb_meta_boxes() {
    if (!class_exists('cmb_Meta_Box')) {
        require_once('metabox/init.php');
    }
}
</pre>


My plugin code would define my new meta box with a filter. If the theme included the metabox/init.php file, my metaboxes would be added before they were rendered. If the class already exists (because the theme required it), my plugin code would have been added; if not, then my plugin could require it.
