### PR TITLE
Enabling custom field types

### DIFF
--- a/init.php
+++ b/init.php
@@ -289,7 +289,8 @@ class cmb_Meta_Box {
 						}
 					echo '</div>'; 
 				break;
-				
+				default:
+					do_action('cmb_render_' . $field['type'] , $field, $meta);
 			}
 			
 			echo '</td>','</tr>';
@@ -342,6 +343,8 @@ class cmb_Meta_Box {
 			if ( $field['type'] == 'text_date_timestamp' ) {
 				$new = strtotime( $new );
 			}
+			
+			$new = apply_filters('cmb_validate_' . $field['type'], $new, $post_id, $field);			
 			
 			// validate meta value
 			if ( isset( $field['validate_func']) ) {


### PR DESCRIPTION
With this new action hook and filter hook, developers using the custom meta box library can create their own field types. With this change to the library, I wrote the following code to add a custom 'text_email' field.

This code renders the custom field. It gets called when the field type is unrecognized:

``` php
add_action('cmb_render_text_email','rrh_cmb_render_text_email',10,2);
function rrh_cmb_render_text_email($field,$meta) {
    echo '<input type="text" name="', $field['id'], '" id="', $field['id'], '" value="', $meta ? $meta : $field['std'], '" style="width:97%" />','<p class="cmb_metabox_description">', $field['desc'], '</p>';
}
```

This code filters the entered value (in this case, removing invalid email addresses) and returns it back so the library can save it.

``` php
add_filter('cmb_validate_text_email','rrh_cmb_validate_text_email');
function rrh_cmb_validate_text_email($new) {
    if (!is_email($new)) {$new = "";}   
    return $new;
}
```
