### PR TITLE
Allow setting 'multiple'

### DIFF
--- a/init.php
+++ b/init.php
@@ -409,7 +409,10 @@ class cmb_Meta_Box {
 
 		foreach ( $this->_meta_box['fields'] as $field ) {
 			$name = $field['id'];			
-			if ( 'multicheck' == $field['type'] ? $field['multiple'] = true : $field['multiple'] = false );      
+
+			if ( ! isset( $field['multiple'] ) )
+				$field['multiple'] = ( 'multicheck' == $field['type'] ) ? true : false;    
+				  
 			$old = get_post_meta( $post_id, $name, !$field['multiple'] /* If multicheck this can be multiple values */ );
 			$new = isset( $_POST[$field['id']] ) ? $_POST[$field['id']] : null;
 			


### PR DESCRIPTION
When using a custom type for a field, currently you can't set the multiple property so the post meta is stored as different meta rows, instead it is all stored in one array in a single meta entry.
