### PR TITLE
Don't show border below last field or if there is only one field.

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /**
  * CMB Styling
  */
-table.cmb_metabox td, table.cmb_metabox th { border-bottom: 1px solid #E9E9E9; }
+table.cmb_metabox > tbody > tr:not(:last-child) > td, table.cmb_metabox tr th { border-bottom: 1px solid #E9E9E9; }
 table.cmb_metabox th { text-align: right; font-weight:bold;}
 table.cmb_metabox th label { margin-top:5px; display:block;}
 p.cmb_metabox_description { color: #AAA; font-style: italic; margin: 2px 0 !important;}


### PR DESCRIPTION
Also stops the border-bottom style from being applied to nested tables (IE with tinymce).
