### PR TITLE
fix for 'tried to get property of non object error' when term ID is invalid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/nbproject/

--- a/init.php
+++ b/init.php
@@ -1,12 +1,12 @@
 <?php
 /*
-Script Name: 	Custom Metaboxes and Fields
-Contributors: 	Andrew Norcross (@norcross / andrewnorcross.com)
-				Jared Atchison (@jaredatch / jaredatchison.com)
-				Bill Erickson (@billerickson / billerickson.net)
-Description: 	This will create metaboxes with custom fields that will blow your mind.
-Version: 		0.9
-*/
+  Script Name: 	Custom Metaboxes and Fields
+  Contributors: 	Andrew Norcross (@norcross / andrewnorcross.com)
+  Jared Atchison (@jaredatch / jaredatchison.com)
+  Bill Erickson (@billerickson / billerickson.net)
+  Description: 	This will create metaboxes with custom fields that will blow your mind.
+  Version: 		0.9
+ */
 
 /**
  * Released under the GPL license
@@ -27,13 +27,12 @@ Version: 		0.9
  * GNU General Public License for more details.
  * **********************************************************************
  */
+/* * **********************************************************************
+  You should not edit the code below or things might explode!
+ * *********************************************************************** */
 
-/************************************************************************
-		You should not edit the code below or things might explode!
-*************************************************************************/
-
-$meta_boxes = array();
-$meta_boxes = apply_filters ( 'cmb_meta_boxes' , $meta_boxes );
+$meta_boxes = array( );
+$meta_boxes = apply_filters( 'cmb_meta_boxes', $meta_boxes );
 foreach ( $meta_boxes as $meta_box ) {
 	$my_box = new cmb_Meta_Box( $meta_box );
 }
@@ -44,12 +43,14 @@ foreach ( $meta_boxes as $meta_box ) {
  * methods in the definition of meta boxes (key 'validate_func' of each field)
  */
 class cmb_Meta_Box_Validate {
+
 	function check_text( $text ) {
-		if ($text != 'hello') {
+		if ( $text != 'hello' ) {
 			return false;
 		}
 		return true;
 	}
+
 }
 
 /**
@@ -63,10 +64,12 @@ define( 'CMB_META_BOX_URL', apply_filters( 'cmb_meta_box_url', trailingslashit( 
  * Create meta boxes
  */
 class cmb_Meta_Box {
+
 	protected $_meta_box;
 
 	function __construct( $meta_box ) {
-		if ( !is_admin() ) return;
+		if ( !is_admin() )
+			return;
 
 		$this->_meta_box = $meta_box;
 
@@ -77,8 +80,8 @@ class cmb_Meta_Box {
 				break;
 			}
 		}
-		
-		global $pagenow;		
+
+		global $pagenow;
 		if ( $upload && in_array( $pagenow, array( 'page.php', 'page-new.php', 'post.php', 'post-new.php' ) ) ) {
 			add_action( 'admin_head', array( &$this, 'add_post_enctype' ) );
 		}
@@ -102,36 +105,37 @@ class cmb_Meta_Box {
 
 	// Add metaboxes
 	function add() {
-		$this->_meta_box['context'] = empty($this->_meta_box['context']) ? 'normal' : $this->_meta_box['context'];
-		$this->_meta_box['priority'] = empty($this->_meta_box['priority']) ? 'high' : $this->_meta_box['priority'];
-		$this->_meta_box['show_on'] = empty( $this->_meta_box['show_on'] ) ? array('key' => false, 'value' => false) : $this->_meta_box['show_on'];
-		
+		$this->_meta_box['context'] = empty( $this->_meta_box['context'] ) ? 'normal' : $this->_meta_box['context'];
+		$this->_meta_box['priority'] = empty( $this->_meta_box['priority'] ) ? 'high' : $this->_meta_box['priority'];
+		$this->_meta_box['show_on'] = empty( $this->_meta_box['show_on'] ) ? array( 'key' => false, 'value' => false ) : $this->_meta_box['show_on'];
+
 		foreach ( $this->_meta_box['pages'] as $page ) {
-			if( apply_filters( 'cmb_show_on', true, $this->_meta_box ) )
-				add_meta_box( $this->_meta_box['id'], $this->_meta_box['title'], array(&$this, 'show'), $page, $this->_meta_box['context'], $this->_meta_box['priority']) ;
+			if ( apply_filters( 'cmb_show_on', true, $this->_meta_box ) )
+				add_meta_box( $this->_meta_box['id'], $this->_meta_box['title'], array( &$this, 'show' ), $page, $this->_meta_box['context'], $this->_meta_box['priority'] );
 		}
 	}
-	
+
 	/**
 	 * Show On Filters
 	 * Use the 'cmb_show_on' filter to further refine the conditions under which a metabox is displayed.
 	 * Below you can limit it by ID and page template
 	 */
-	 
 	// Add for ID 
 	function add_for_id( $display, $meta_box ) {
 		if ( 'id' !== $meta_box['show_on']['key'] )
 			return $display;
 
 		// If we're showing it based on ID, get the current ID					
-		if( isset( $_GET['post'] ) ) $post_id = $_GET['post'];
-		elseif( isset( $_POST['post_ID'] ) ) $post_id = $_POST['post_ID'];
-		if( !isset( $post_id ) )
+		if ( isset( $_GET['post'] ) )
+			$post_id = $_GET['post'];
+		elseif ( isset( $_POST['post_ID'] ) )
+			$post_id = $_POST['post_ID'];
+		if ( !isset( $post_id ) )
 			return false;
-		
+
 		// If value isn't an array, turn it into one	
 		$meta_box['show_on']['value'] = !is_array( $meta_box['show_on']['value'] ) ? array( $meta_box['show_on']['value'] ) : $meta_box['show_on']['value'];
-		
+
 		// If current page id is in the included array, display the metabox
 
 		if ( in_array( $post_id, $meta_box['show_on']['value'] ) )
@@ -139,65 +143,74 @@ class cmb_Meta_Box {
 		else
 			return false;
 	}
-	
+
 	// Add for Page Template
 	function add_for_page_template( $display, $meta_box ) {
-		if( 'page-template' !== $meta_box['show_on']['key'] )
+		if ( 'page-template' !== $meta_box['show_on']['key'] )
 			return $display;
-			
+
 		// Get the current ID
-		if( isset( $_GET['post'] ) ) $post_id = $_GET['post'];
-		elseif( isset( $_POST['post_ID'] ) ) $post_id = $_POST['post_ID'];
-		if( !( isset( $post_id ) || is_page() ) ) return false;
-			
+		if ( isset( $_GET['post'] ) )
+			$post_id = $_GET['post'];
+		elseif ( isset( $_POST['post_ID'] ) )
+			$post_id = $_POST['post_ID'];
+		if ( !( isset( $post_id ) || is_page() ) )
+			return false;
+
 		// Get current template
 		$current_template = get_post_meta( $post_id, '_wp_page_template', true );
-		
+
 		// If value isn't an array, turn it into one	
 		$meta_box['show_on']['value'] = !is_array( $meta_box['show_on']['value'] ) ? array( $meta_box['show_on']['value'] ) : $meta_box['show_on']['value'];
 
 		// See if there's a match
-		if( in_array( $current_template, $meta_box['show_on']['value'] ) )
+		if ( in_array( $current_template, $meta_box['show_on']['value'] ) )
 			return true;
 		else
 			return false;
 	}
-	
+
 	// Show fields
 	function show() {
 
 		global $post;
 
 		// Use nonce for verification
-		echo '<input type="hidden" name="wp_meta_box_nonce" value="', wp_create_nonce( basename(__FILE__) ), '" />';
+		echo '<input type="hidden" name="wp_meta_box_nonce" value="', wp_create_nonce( basename( __FILE__ ) ), '" />';
 		echo '<table class="form-table cmb_metabox">';
 
 		foreach ( $this->_meta_box['fields'] as $field ) {
 			// Set up blank or default values for empty ones
-			if ( !isset( $field['name'] ) ) $field['name'] = '';
-			if ( !isset( $field['desc'] ) ) $field['desc'] = '';
-			if ( !isset( $field['std'] ) ) $field['std'] = '';
-			if ( 'file' == $field['type'] && !isset( $field['allow'] ) ) $field['allow'] = array( 'url', 'attachment' );
-			if ( 'file' == $field['type'] && !isset( $field['save_id'] ) )  $field['save_id']  = false;
-			if ( 'multicheck' == $field['type'] ) $field['multiple'] = true;  
-						
+			if ( !isset( $field['name'] ) )
+				$field['name'] = '';
+			if ( !isset( $field['desc'] ) )
+				$field['desc'] = '';
+			if ( !isset( $field['std'] ) )
+				$field['std'] = '';
+			if ( 'file' == $field['type'] && !isset( $field['allow'] ) )
+				$field['allow'] = array( 'url', 'attachment' );
+			if ( 'file' == $field['type'] && !isset( $field['save_id'] ) )
+				$field['save_id'] = false;
+			if ( 'multicheck' == $field['type'] )
+				$field['multiple'] = true;
+
 			$meta = get_post_meta( $post->ID, $field['id'], 'multicheck' != $field['type'] /* If multicheck this can be multiple values */ );
 
 			echo '<tr>';
-	
+
 			if ( $field['type'] == "title" ) {
 				echo '<td colspan="2">';
 			} else {
-				if( $this->_meta_box['show_names'] == true ) {
+				if ( $this->_meta_box['show_names'] == true ) {
 					echo '<th style="width:18%"><label for="', $field['id'], '">', $field['name'], '</label></th>';
-				}			
+				}
 				echo '<td>';
-			}		
-						
+			}
+
 			switch ( $field['type'] ) {
 
 				case 'text':
-					echo '<input type="text" name="', $field['id'], '" id="', $field['id'], '" value="', '' !== $meta ? $meta : $field['std'], '" />','<p class="cmb_metabox_description">', $field['desc'], '</p>';
+					echo '<input type="text" name="', $field['id'], '" id="', $field['id'], '" value="', '' !== $meta ? $meta : $field['std'], '" />', '<p class="cmb_metabox_description">', $field['desc'], '</p>';
 					break;
 				case 'text_small':
 					echo '<input class="cmb_text_small" type="text" name="', $field['id'], '" id="', $field['id'], '" value="', '' !== $meta ? $meta : $field['std'], '" /><span class="cmb_metabox_description">', $field['desc'], '</span>';
@@ -218,7 +231,7 @@ class cmb_Meta_Box {
 					break;
 				case 'text_time':
 					echo '<input class="cmb_timepicker text_time" type="text" name="', $field['id'], '" id="', $field['id'], '" value="', '' !== $meta ? $meta : $field['std'], '" /><span class="cmb_metabox_description">', $field['desc'], '</span>';
-					break;					
+					break;
 				case 'text_money':
 					echo '$ <input class="cmb_text_money" type="text" name="', $field['id'], '" id="', $field['id'], '" value="', '' !== $meta ? $meta : $field['std'], '" /><span class="cmb_metabox_description">', $field['desc'], '</span>';
 					break;
@@ -227,33 +240,35 @@ class cmb_Meta_Box {
 					$hex_color = '(([a-fA-F0-9]){3}){1,2}$';
 					if ( preg_match( '/^' . $hex_color . '/i', $meta ) ) // Value is just 123abc, so prepend #.
 						$meta = '#' . $meta;
-					elseif ( ! preg_match( '/^#' . $hex_color . '/i', $meta ) ) // Value doesn't match #123abc, so sanitize to just #.
+					elseif ( !preg_match( '/^#' . $hex_color . '/i', $meta ) ) // Value doesn't match #123abc, so sanitize to just #.
 						$meta = "#";
 					echo '<input class="cmb_colorpicker cmb_text_small" type="text" name="', $field['id'], '" id="', $field['id'], '" value="', $meta, '" /><span class="cmb_metabox_description">', $field['desc'], '</span>';
 					break;
 				case 'textarea':
-					echo '<textarea name="', $field['id'], '" id="', $field['id'], '" cols="60" rows="10">', '' !== $meta ? $meta : $field['std'], '</textarea>','<p class="cmb_metabox_description">', $field['desc'], '</p>';
+					echo '<textarea name="', $field['id'], '" id="', $field['id'], '" cols="60" rows="10">', '' !== $meta ? $meta : $field['std'], '</textarea>', '<p class="cmb_metabox_description">', $field['desc'], '</p>';
 					break;
 				case 'textarea_small':
-					echo '<textarea name="', $field['id'], '" id="', $field['id'], '" cols="60" rows="4">', '' !== $meta ? $meta : $field['std'], '</textarea>','<p class="cmb_metabox_description">', $field['desc'], '</p>';
+					echo '<textarea name="', $field['id'], '" id="', $field['id'], '" cols="60" rows="4">', '' !== $meta ? $meta : $field['std'], '</textarea>', '<p class="cmb_metabox_description">', $field['desc'], '</p>';
 					break;
 				case 'textarea_code':
-					echo '<textarea name="', $field['id'], '" id="', $field['id'], '" cols="60" rows="10" class="cmb_textarea_code">', '' !== $meta ? $meta : $field['std'], '</textarea>','<p class="cmb_metabox_description">', $field['desc'], '</p>';
-					break;					
+					echo '<textarea name="', $field['id'], '" id="', $field['id'], '" cols="60" rows="10" class="cmb_textarea_code">', '' !== $meta ? $meta : $field['std'], '</textarea>', '<p class="cmb_metabox_description">', $field['desc'], '</p>';
+					break;
 				case 'select':
-					if( empty( $meta ) && !empty( $field['std'] ) ) $meta = $field['std'];
+					if ( empty( $meta ) && !empty( $field['std'] ) )
+						$meta = $field['std'];
 					echo '<select name="', $field['id'], '" id="', $field['id'], '">';
-					foreach ($field['options'] as $option) {
+					foreach ( $field['options'] as $option ) {
 						echo '<option value="', $option['value'], '"', $meta == $option['value'] ? ' selected="selected"' : '', '>', $option['name'], '</option>';
 					}
 					echo '</select>';
 					echo '<p class="cmb_metabox_description">', $field['desc'], '</p>';
 					break;
 				case 'radio_inline':
-					if( empty( $meta ) && !empty( $field['std'] ) ) $meta = $field['std'];
+					if ( empty( $meta ) && !empty( $field['std'] ) )
+						$meta = $field['std'];
 					echo '<div class="cmb_radio_inline">';
 					$i = 1;
-					foreach ($field['options'] as $option) {
+					foreach ( $field['options'] as $option ) {
 						echo '<div class="cmb_radio_inline_option"><input type="radio" name="', $field['id'], '" id="', $field['id'], $i, '" value="', $option['value'], '"', $meta == $option['value'] ? ' checked="checked"' : '', ' /><label for="', $field['id'], $i, '">', $option['name'], '</label></div>';
 						$i++;
 					}
@@ -261,11 +276,12 @@ class cmb_Meta_Box {
 					echo '<p class="cmb_metabox_description">', $field['desc'], '</p>';
 					break;
 				case 'radio':
-					if( empty( $meta ) && !empty( $field['std'] ) ) $meta = $field['std'];
+					if ( empty( $meta ) && !empty( $field['std'] ) )
+						$meta = $field['std'];
 					echo '<ul>';
 					$i = 1;
-					foreach ($field['options'] as $option) {
-						echo '<li><input type="radio" name="', $field['id'], '" id="', $field['id'], $i,'" value="', $option['value'], '"', $meta == $option['value'] ? ' checked="checked"' : '', ' /><label for="', $field['id'], $i, '">', $option['name'].'</label></li>';
+					foreach ( $field['options'] as $option ) {
+						echo '<li><input type="radio" name="', $field['id'], '" id="', $field['id'], $i, '" value="', $option['value'], '"', $meta == $option['value'] ? ' checked="checked"' : '', ' /><label for="', $field['id'], $i, '">', $option['name'] . '</label></li>';
 						$i++;
 					}
 					echo '</ul>';
@@ -281,127 +297,137 @@ class cmb_Meta_Box {
 					foreach ( $field['options'] as $value => $name ) {
 						// Append `[]` to the name to get multiple values
 						// Use in_array() to check whether the current option should be checked
-						echo '<li><input type="checkbox" name="', $field['id'], '[]" id="', $field['id'], $i, '" value="', $value, '"', in_array( $value, $meta ) ? ' checked="checked"' : '', ' /><label for="', $field['id'], $i, '">', $name, '</label></li>';	
+						echo '<li><input type="checkbox" name="', $field['id'], '[]" id="', $field['id'], $i, '" value="', $value, '"', in_array( $value, $meta ) ? ' checked="checked"' : '', ' /><label for="', $field['id'], $i, '">', $name, '</label></li>';
 						$i++;
 					}
 					echo '</ul>';
-					echo '<span class="cmb_metabox_description">', $field['desc'], '</span>';					
-					break;		
+					echo '<span class="cmb_metabox_description">', $field['desc'], '</span>';
+					break;
 				case 'title':
 					echo '<h5 class="cmb_metabox_title">', $field['name'], '</h5>';
 					echo '<p class="cmb_metabox_description">', $field['desc'], '</p>';
 					break;
 				case 'wysiwyg':
-					wp_editor( $meta ? $meta : $field['std'], $field['id'], isset( $field['options'] ) ? $field['options'] : array() );
-			        echo '<p class="cmb_metabox_description">', $field['desc'], '</p>';
+					wp_editor( $meta ? $meta : $field['std'], $field['id'], isset( $field['options'] ) ? $field['options'] : array( )  );
+					echo '<p class="cmb_metabox_description">', $field['desc'], '</p>';
 					break;
 				case 'taxonomy_select':
 					echo '<select name="', $field['id'], '" id="', $field['id'], '">';
-					$names= wp_get_object_terms( $post->ID, $field['taxonomy'] );
+					$names = wp_get_object_terms( $post->ID, $field['taxonomy'] );
 					$terms = get_terms( $field['taxonomy'], 'hide_empty=0' );
-					foreach ( $terms as $term ) {
-						if (!is_wp_error( $names ) && !empty( $names ) && !strcmp( $term->slug, $names[0]->slug ) ) {
-							echo '<option value="' . $term->slug . '" selected>' . $term->name . '</option>';
-						} else {
-							echo '<option value="' . $term->slug . '  ' , $meta == $term->slug ? $meta : ' ' ,'  ">' . $term->name . '</option>';
+					$count = count( $terms );
+					if ( ! is_wp_error( $terms ) && $count > 0 ) {	
+						foreach ( $terms as $term ) {
+							if ( !is_wp_error( $names ) && !empty( $names ) && !strcmp( $term->slug, $names[0]->slug ) ) {
+								echo '<option value="' . $term->slug . '" selected>' . $term->name . '</option>';
+							} else {
+								echo '<option value="' . $term->slug . '  ', $meta == $term->slug ? $meta : ' ', '  ">' . $term->name . '</option>';
+							}
 						}
 					}
 					echo '</select>';
 					echo '<p class="cmb_metabox_description">', $field['desc'], '</p>';
 					break;
 				case 'taxonomy_radio':
-					$names= wp_get_object_terms( $post->ID, $field['taxonomy'] );
+					$names = wp_get_object_terms( $post->ID, $field['taxonomy'] );
 					$terms = get_terms( $field['taxonomy'], 'hide_empty=0' );
-					echo '<ul>';
-					foreach ( $terms as $term ) {
-						if ( !is_wp_error( $names ) && !empty( $names ) && !strcmp( $term->slug, $names[0]->slug ) ) {
-							echo '<li><input type="radio" name="', $field['id'], '" value="'. $term->slug . '" checked>' . $term->name . '</li>';
-						} else {
-							echo '<li><input type="radio" name="', $field['id'], '" value="' . $term->slug . '  ' , $meta == $term->slug ? $meta : ' ' ,'  ">' . $term->name .'</li>';
-						}
-					}
-					echo '</ul>';
+					$count = count( $terms );
+					if ( ! is_wp_error( $terms ) && $count > 0 ) {					
+						echo '<ul>';
+
+							foreach ( $terms as $term ) {
+								if ( !is_wp_error( $names ) && !empty( $names ) && !strcmp( $term->slug, $names[0]->slug ) ) {
+									echo '<li><input type="radio" name="', $field['id'], '" value="' . $term->slug . '" checked>' . $term->name . '</li>';
+								} else {
+									echo '<li><input type="radio" name="', $field['id'], '" value="' . $term->slug . '  ', $meta == $term->slug ? $meta : ' ', '  ">' . $term->name . '</li>';
+								}
+							}
+
+						echo '</ul>';
+					}					
 					echo '<p class="cmb_metabox_description">', $field['desc'], '</p>';
 					break;
 				case 'taxonomy_multicheck':
 					echo '<ul>';
 					$names = wp_get_object_terms( $post->ID, $field['taxonomy'] );
 					$terms = get_terms( $field['taxonomy'], 'hide_empty=0' );
-					foreach ($terms as $term) {
-						echo '<li><input type="checkbox" name="', $field['id'], '[]" id="', $field['id'], '" value="', $term->name , '"'; 
-						foreach ($names as $name) {
-							if ( $term->slug == $name->slug ){ echo ' checked="checked" ';};
+					foreach ( $terms as $term ) {
+						echo '<li><input type="checkbox" name="', $field['id'], '[]" id="', $field['id'], '" value="', $term->name, '"';
+						foreach ( $names as $name ) {
+							if ( $term->slug == $name->slug ) {
+								echo ' checked="checked" ';
+							};
 						}
-						echo' /><label>', $term->name , '</label></li>';
+						echo' /><label>', $term->name, '</label></li>';
 					}
-				break;
+					break;
 				case 'file_list':
 					echo '<input class="cmb_upload_file" type="text" size="36" name="', $field['id'], '" value="" />';
 					echo '<input class="cmb_upload_button button" type="button" value="Upload File" />';
 					echo '<p class="cmb_metabox_description">', $field['desc'], '</p>';
-						$args = array(
-								'post_type' => 'attachment',
-								'numberposts' => null,
-								'post_status' => null,
-								'post_parent' => $post->ID
-							);
-							$attachments = get_posts($args);
-							if ($attachments) {
-								echo '<ul class="attach_list">';
-								foreach ($attachments as $attachment) {
-									echo '<li>'.wp_get_attachment_link($attachment->ID, 'thumbnail', 0, 0, 'Download');
-									echo '<span>';
-									echo apply_filters('the_title', '&nbsp;'.$attachment->post_title);
-									echo '</span></li>';
-								}
-								echo '</ul>';
-							}
-						break;
+					$args = array(
+						'post_type' => 'attachment',
+						'numberposts' => null,
+						'post_status' => null,
+						'post_parent' => $post->ID
+					);
+					$attachments = get_posts( $args );
+					if ( $attachments ) {
+						echo '<ul class="attach_list">';
+						foreach ( $attachments as $attachment ) {
+							echo '<li>' . wp_get_attachment_link( $attachment->ID, 'thumbnail', 0, 0, 'Download' );
+							echo '<span>';
+							echo apply_filters( 'the_title', '&nbsp;' . $attachment->post_title );
+							echo '</span></li>';
+						}
+						echo '</ul>';
+					}
+					break;
 				case 'file':
 					$input_type_url = "hidden";
 					if ( 'url' == $field['allow'] || ( is_array( $field['allow'] ) && in_array( 'url', $field['allow'] ) ) )
-						$input_type_url="text";
+						$input_type_url = "text";
 					echo '<input class="cmb_upload_file" type="' . $input_type_url . '" size="45" id="', $field['id'], '" name="', $field['id'], '" value="', $meta, '" />';
 					echo '<input class="cmb_upload_button button" type="button" value="Upload File" />';
-					echo '<input class="cmb_upload_file_id" type="hidden" id="', $field['id'], '_id" name="', $field['id'], '_id" value="', get_post_meta( $post->ID, $field['id'] . "_id",true), '" />';					
+					echo '<input class="cmb_upload_file_id" type="hidden" id="', $field['id'], '_id" name="', $field['id'], '_id" value="', get_post_meta( $post->ID, $field['id'] . "_id", true ), '" />';
 					echo '<p class="cmb_metabox_description">', $field['desc'], '</p>';
-					echo '<div id="', $field['id'], '_status" class="cmb_upload_status">';	
-						if ( $meta != '' ) { 
-							$check_image = preg_match( '/(^.*\.jpg|jpeg|png|gif|ico*)/i', $meta );
-							if ( $check_image ) {
-								echo '<div class="img_status">';
-								echo '<img src="', $meta, '" alt="" />';
-								echo '<a href="#" class="cmb_remove_file_button" rel="', $field['id'], '">Remove Image</a>';
-								echo '</div>';
-							} else {
-								$parts = explode( '/', $meta );
-								for( $i = 0; $i < count( $parts ); ++$i ) {
-									$title = $parts[$i];
-								} 
-								echo 'File: <strong>', $title, '</strong>&nbsp;&nbsp;&nbsp; (<a href="', $meta, '" target="_blank" rel="external">Download</a> / <a href="#" class="cmb_remove_file_button" rel="', $field['id'], '">Remove</a>)';
-							}	
+					echo '<div id="', $field['id'], '_status" class="cmb_upload_status">';
+					if ( $meta != '' ) {
+						$check_image = preg_match( '/(^.*\.jpg|jpeg|png|gif|ico*)/i', $meta );
+						if ( $check_image ) {
+							echo '<div class="img_status">';
+							echo '<img src="', $meta, '" alt="" />';
+							echo '<a href="#" class="cmb_remove_file_button" rel="', $field['id'], '">Remove Image</a>';
+							echo '</div>';
+						} else {
+							$parts = explode( '/', $meta );
+							for ( $i = 0; $i < count( $parts ); ++$i ) {
+								$title = $parts[$i];
+							}
+							echo 'File: <strong>', $title, '</strong>&nbsp;&nbsp;&nbsp; (<a href="', $meta, '" target="_blank" rel="external">Download</a> / <a href="#" class="cmb_remove_file_button" rel="', $field['id'], '">Remove</a>)';
 						}
-					echo '</div>'; 
-				break;
+					}
+					echo '</div>';
+					break;
 				default:
-					do_action('cmb_render_' . $field['type'] , $field, $meta);
+					do_action( 'cmb_render_' . $field['type'], $field, $meta );
 			}
-			
-			echo '</td>','</tr>';
+
+			echo '</td>', '</tr>';
 		}
 		echo '</table>';
 	}
 
 	// Save data from metabox
-	function save( $post_id)  {
+	function save( $post_id ) {
 
 		// verify nonce
-		if ( ! isset( $_POST['wp_meta_box_nonce'] ) || !wp_verify_nonce( $_POST['wp_meta_box_nonce'], basename(__FILE__) ) ) {
+		if ( !isset( $_POST['wp_meta_box_nonce'] ) || !wp_verify_nonce( $_POST['wp_meta_box_nonce'], basename( __FILE__ ) ) ) {
 			return $post_id;
 		}
 
 		// check autosave
-		if ( defined('DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return $post_id;
 		}
 
@@ -415,26 +441,26 @@ class cmb_Meta_Box {
 		}
 
 		foreach ( $this->_meta_box['fields'] as $field ) {
-			$name = $field['id'];			
+			$name = $field['id'];
 
-			if ( ! isset( $field['multiple'] ) )
-				$field['multiple'] = ( 'multicheck' == $field['type'] ) ? true : false;    
-				  
+			if ( !isset( $field['multiple'] ) )
+				$field['multiple'] = ( 'multicheck' == $field['type'] ) ? true : false;
+
 			$old = get_post_meta( $post_id, $name, !$field['multiple'] /* If multicheck this can be multiple values */ );
 			$new = isset( $_POST[$field['id']] ) ? $_POST[$field['id']] : null;
-			
-			if ( in_array( $field['type'], array( 'taxonomy_select', 'taxonomy_radio', 'taxonomy_multicheck' ) ) )  {	
-				$new = wp_set_object_terms( $post_id, $new, $field['taxonomy'] );	
+
+			if ( in_array( $field['type'], array( 'taxonomy_select', 'taxonomy_radio', 'taxonomy_multicheck' ) ) ) {
+				$new = wp_set_object_terms( $post_id, $new, $field['taxonomy'] );
 			}
-			
+
 			if ( ($field['type'] == 'textarea') || ($field['type'] == 'textarea_small') ) {
 				$new = htmlspecialchars( $new );
 			}
 
-			if ( ($field['type'] == 'textarea_code') ) {
+			if ( ($field['type'] == 'textarea_code' ) ) {
 				$new = htmlspecialchars_decode( $new );
 			}
-			
+
 			if ( $field['type'] == 'text_date_timestamp' ) {
 				$new = strtotime( $new );
 			}
@@ -443,28 +469,28 @@ class cmb_Meta_Box {
 				$string = $new['date'] . ' ' . $new['time'];
 				$new = strtotime( $string );
 			}
-			
-			$new = apply_filters('cmb_validate_' . $field['type'], $new, $post_id, $field);			
-			
+
+			$new = apply_filters( 'cmb_validate_' . $field['type'], $new, $post_id, $field );
+
 			// validate meta value
-			if ( isset( $field['validate_func']) ) {
-				$ok = call_user_func( array( 'cmb_Meta_Box_Validate', $field['validate_func']), $new );
+			if ( isset( $field['validate_func'] ) ) {
+				$ok = call_user_func( array( 'cmb_Meta_Box_Validate', $field['validate_func'] ), $new );
 				if ( $ok === false ) { // pass away when meta value is invalid
 					continue;
 				}
 			} elseif ( $field['multiple'] ) {
-				delete_post_meta( $post_id, $name );	
+				delete_post_meta( $post_id, $name );
 				if ( !empty( $new ) ) {
 					foreach ( $new as $add_new ) {
 						add_post_meta( $post_id, $name, $add_new, false );
 					}
-				}			
-			} elseif ( '' !== $new && $new != $old  ) {
+				}
+			} elseif ( '' !== $new && $new != $old ) {
 				update_post_meta( $post_id, $name, $new );
 			} elseif ( '' == $new ) {
 				delete_post_meta( $post_id, $name );
 			}
-			
+
 			if ( 'file' == $field['type'] ) {
 				$name = $field['id'] . "_id";
 				$old = get_post_meta( $post_id, $name, !$field['multiple'] /* If multicheck this can be multiple values */ );
@@ -479,54 +505,60 @@ class cmb_Meta_Box {
 				} elseif ( '' == $new && $old ) {
 					delete_post_meta( $post_id, $name, $old );
 				}
-			}			
+			}
 		}
 	}
+
 }
 
 /**
  * Adding scripts and styles
  */
 function cmb_scripts( $hook ) {
-  	if ( $hook == 'post.php' || $hook == 'post-new.php' || $hook == 'page-new.php' || $hook == 'page.php' ) {
+	if ( $hook == 'post.php' || $hook == 'post-new.php' || $hook == 'page-new.php' || $hook == 'page.php' ) {
 		wp_register_script( 'cmb-timepicker', CMB_META_BOX_URL . 'js/jquery.timePicker.min.js' );
 		wp_register_script( 'cmb-scripts', CMB_META_BOX_URL . 'js/cmb.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'media-upload', 'thickbox', 'farbtastic' ) );
 		wp_enqueue_script( 'cmb-timepicker' );
 		wp_enqueue_script( 'cmb-scripts' );
 		wp_register_style( 'cmb-styles', CMB_META_BOX_URL . 'style.css', array( 'thickbox', 'farbtastic' ) );
 		wp_enqueue_style( 'cmb-styles' );
-  	}
-}
-add_action( 'admin_enqueue_scripts', 'cmb_scripts', 10 );
-
-function cmb_editor_footer_scripts() { ?>
-	<?php
-	if ( isset( $_GET['cmb_force_send'] ) && 'true' == $_GET['cmb_force_send'] ) { 
-		$label = $_GET['cmb_send_label']; 
-		if ( empty( $label ) ) $label="Select File";
-		?>	
-		<script type="text/javascript">
-		jQuery(function($) {
-			$('td.savesend input').val('<?php echo $label; ?>');
-		});
-		</script>
-		<?php 
 	}
 }
+
+add_action( 'admin_enqueue_scripts', 'cmb_scripts', 10 );
+
+function cmb_editor_footer_scripts() {
+	?>
+	<?php
+	if ( isset( $_GET['cmb_force_send'] ) && 'true' == $_GET['cmb_force_send'] ) {
+		$label = $_GET['cmb_send_label'];
+		if ( empty( $label ) )
+			$label = "Select File";
+		?>	
+		<script type="text/javascript">
+			jQuery(function($) {
+				$('td.savesend input').val('<?php echo $label; ?>');
+			});
+		</script>
+		<?php
+	}
+}
+
 add_action( 'admin_print_footer_scripts', 'cmb_editor_footer_scripts', 99 );
 
 // Force 'Insert into Post' button from Media Library 
 add_filter( 'get_media_item_args', 'cmb_force_send' );
+
 function cmb_force_send( $args ) {
-		
+
 	// if the Gallery tab is opened from a custom meta box field, add Insert Into Post button	
 	if ( isset( $_GET['cmb_force_send'] ) && 'true' == $_GET['cmb_force_send'] )
 		$args['send'] = true;
-	
+
 	// if the From Computer tab is opened AT ALL, add Insert Into Post button after an image is uploaded	
 	if ( isset( $_POST['attachment_id'] ) && '' != $_POST["attachment_id"] ) {
-		
-		$args['send'] = true;		
+
+		$args['send'] = true;
 
 		// TO DO: Are there any conditions in which we don't want the Insert Into Post 
 		// button added? For example, if a post type supports thumbnails, does not support
@@ -535,8 +567,8 @@ function cmb_force_send( $args ) {
 		// $attachment_ancestors = get_post_ancestors( $_POST["attachment_id"] );
 		// $attachment_parent_post_type = get_post_type( $attachment_ancestors[0] );
 		// $post_type_object = get_post_type_object( $attachment_parent_post_type );
-	}		
-	
+	}
+
 	// change the label of the button on the From Computer tab
 	if ( isset( $_POST['attachment_id'] ) && '' != $_POST["attachment_id"] ) {
 
@@ -562,8 +594,8 @@ function cmb_force_send( $args ) {
 			</script>
 		';
 	}
-	 
-    return $args;
 
+	return $args;
 }
+
 // End. That's it, folks! //


### PR DESCRIPTION
Was getting 'tried to get property of non object' errors on $terms
variable in init.php
Added check for is_wp-error and count > 0 for these cases. occurs if the
taxonomy metaboxes term ID is invalid

Probably needs further testing
