### PR TITLE
Fix CMB_META_BOX_URL bug on Windows.

### DIFF
--- a/init.php
+++ b/init.php
@@ -58,7 +58,13 @@ class cmb_Meta_Box_Validate {
  * This may need to be filtered for local Window installations.
  * If resources do not load, please check the wiki for details.
  */
-define( 'CMB_META_BOX_URL', apply_filters( 'cmb_meta_box_url', trailingslashit( str_replace( WP_CONTENT_DIR, WP_CONTENT_URL, dirname( __FILE__ ) ) ) ) );
+if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+       //winblows
+    define( 'CMB_META_BOX_URL', trailingslashit( str_replace( DIRECTORY_SEPARATOR, '/', str_replace( str_replace( '/', DIRECTORY_SEPARATOR, WP_CONTENT_DIR ), WP_CONTENT_URL, dirname(__FILE__) ) ) ) );
+    
+} else {
+    define( 'CMB_META_BOX_URL', apply_filters( 'cmb_meta_box_url', trailingslashit( str_replace( WP_CONTENT_DIR, WP_CONTENT_URL, dirname( __FILE__ ) ) ) ) );
+}
 
 /**
  * Create meta boxes


### PR DESCRIPTION
Replace the define constant of CMB_META_BOX_URL to works with Windows/Linux/Mac OSX.
