### PR TITLE
Adding support for WP3.5 colorpicker

### DIFF
--- a/init.php
+++ b/init.php
@@ -487,12 +487,23 @@ class cmb_Meta_Box {
  * Adding scripts and styles
  */
 function cmb_scripts( $hook ) {
+	global $wp_version;
   	if ( $hook == 'post.php' || $hook == 'post-new.php' || $hook == 'page-new.php' || $hook == 'page.php' ) {
+		$cmb_script_array = array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'media-upload', 'thickbox' );
+		$cmb_style_array = array( 'thickbox' );
+		if( 3.5 <= $wp_version ){
+			$cmb_script_array[] = 'wp-color-picker';
+			$cmb_style_array[] = 'wp-color-picker';
+		}else{
+			$cmb_script_array[] = 'farbtastic';
+			$cmb_style_array[] = 'farbtastic';
+		}
 		wp_register_script( 'cmb-timepicker', CMB_META_BOX_URL . 'js/jquery.timePicker.min.js' );
-		wp_register_script( 'cmb-scripts', CMB_META_BOX_URL . 'js/cmb.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'media-upload', 'thickbox', 'farbtastic' ) );
+		wp_register_script( 'cmb-scripts', CMB_META_BOX_URL . 'js/cmb.js', $cmb_script_array, '0.9.1' );
+		wp_localize_script( 'cmb-scripts', 'cmb_ajax_data', array( 'ajax_nonce' => wp_create_nonce( 'ajax_nonce' ), 'post_id' => get_the_ID() ) );
 		wp_enqueue_script( 'cmb-timepicker' );
 		wp_enqueue_script( 'cmb-scripts' );
-		wp_register_style( 'cmb-styles', CMB_META_BOX_URL . 'style.css', array( 'thickbox', 'farbtastic' ) );
+		wp_register_style( 'cmb-styles', CMB_META_BOX_URL . 'style.css', $cmb_style_array );
 		wp_enqueue_style( 'cmb-styles' );
   	}
 }

--- a/js/cmb.js
+++ b/js/cmb.js
@@ -45,16 +45,20 @@ jQuery(document).ready(function ($) {
 	/**
 	 * Initialize color picker
 	 */
-    $('input:text.cmb_colorpicker').each(function (i) {
-        $(this).after('<div id="picker-' + i + '" style="z-index: 1000; background: #EEE; border: 1px solid #CCC; position: absolute; display: block;"></div>');
-        $('#picker-' + i).hide().farbtastic($(this));
-    })
-    .focus(function() {
-        $(this).next().show();
-    })
-    .blur(function() {
-        $(this).next().hide();
-    });
+ 	if( typeof jQuery.wp === 'object' && typeof jQuery.wp.wpColorPicker === 'function' ){
+ 		$('input:text.cmb_colorpicker').wpColorPicker();
+ 	}else{
+ 	    $('input:text.cmb_colorpicker').each(function (i) {
+ 	        $(this).after('<div id="picker-' + i + '" style="z-index: 1000; background: #EEE; border: 1px solid #CCC; position: absolute; display: block;"></div>');
+ 	        $('#picker-' + i).hide().farbtastic($(this));
+ 	    })
+ 	    .focus(function() {
+ 	        $(this).next().show();
+ 	    })
+ 	    .blur(function() {
+ 	        $(this).next().hide();
+ 	    });		
+ 	}
 
 	/**
 	 * File and image upload handling


### PR DESCRIPTION
This should work and fall back gracefully for WP installs < 3.5
