### PR TITLE
Fix assumption that plugins folder is in the wp-content folder

### DIFF
--- a/init.php
+++ b/init.php
@@ -63,7 +63,13 @@ if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
     define( 'CMB_META_BOX_URL', trailingslashit( str_replace( DIRECTORY_SEPARATOR, '/', str_replace( str_replace( '/', DIRECTORY_SEPARATOR, WP_CONTENT_DIR ), WP_CONTENT_URL, dirname(__FILE__) ) ) ) );
 
 } else {
-    define( 'CMB_META_BOX_URL', apply_filters( 'cmb_meta_box_url', trailingslashit( str_replace( WP_CONTENT_DIR, WP_CONTENT_URL, dirname( __FILE__ ) ) ) ) );
+  define('CMB_META_BOX_URL', apply_filters('cmb_meta_box_url',
+    trailingslashit(str_replace(
+      array(WP_CONTENT_DIR, WP_PLUGIN_DIR),
+      array(WP_CONTENT_URL, WP_PLUGIN_URL),
+      dirname( __FILE__ )
+    ))
+  ));
 }
 
 /**


### PR DESCRIPTION
If you have defined WP_PLUGIN_\* outside of WP_CONTENT_\* the path to the current plugin that is including CMB_META_BOX is incorrect.

Didn't touch windows path, but similar change may be required.
