### PR TITLE
Select timezone

### DIFF
--- a/example-functions.php
+++ b/example-functions.php
@@ -70,6 +70,12 @@ function cmb_sample_metaboxes( array $meta_boxes ) {
 	            'id'   => $prefix . 'test_time',
 	            'type' => 'text_time',
 	        ),
+	        array(
+	            'name' => 'Time zone',
+	            'desc' => 'Time zone'
+	            'id'   => $prefix . 'timezone',
+	            'type' => 'select_timezone',
+	        ),
 			array(
 				'name'   => 'Test Money',
 				'desc'   => 'field description (optional)',

--- a/init.php
+++ b/init.php
@@ -230,11 +230,28 @@ class cmb_Meta_Box {
 					break;
 
 				case 'text_datetime_timestamp':
+
+					// This will be used if there is a select_timezone set for this field
+					$tz_offset = cmb_field_timezone_offset($field, $post->ID);
+					if (!empty($tz_offset)) {
+						$meta -= $tz_offset;
+					}
+
 					echo '<input class="cmb_text_small cmb_datepicker" type="text" name="', $field['id'], '[date]" id="', $field['id'], '_date" value="', '' !== $meta ? date( 'm\/d\/Y', $meta ) : $field['std'], '" />';
 					echo '<input class="cmb_timepicker text_time" type="text" name="', $field['id'], '[time]" id="', $field['id'], '_time" value="', '' !== $meta ? date( 'h:i A', $meta ) : $field['std'], '" /><span class="cmb_metabox_description" >', $field['desc'], '</span>';
 					break;
 				case 'text_time':
 					echo '<input class="cmb_timepicker text_time" type="text" name="', $field['id'], '" id="', $field['id'], '" value="', '' !== $meta ? $meta : $field['std'], '" /><span class="cmb_metabox_description">', $field['desc'], '</span>';
+					break;
+				case 'select_timezone':
+					$meta = '' !== $meta ? $meta : $field['std'];
+					if ('' === $meta) {
+						$meta = cmb_timezone_string();
+					}
+
+					echo '<select name="', $field['id'], '" id="', $field['id'], '">';
+					echo wp_timezone_choice( $meta );
+					echo '</select>';
 					break;
 				case 'text_money':
 					echo ! empty( $field['before'] ) ? '' : '$', ' <input class="cmb_text_money" type="text" name="', $field['id'], '" id="', $field['id'], '" value="', '' !== $meta ? $meta : $field['std'], '" /><span class="cmb_metabox_description">', $field['desc'], '</span>';
@@ -491,6 +508,11 @@ class cmb_Meta_Box {
 			if ( $type_comp == true && $field['type'] == 'text_datetime_timestamp' ) {
 				$string = $new['date'] . ' ' . $new['time'];
 				$new = strtotime( $string );
+
+				$tz_offset = cmb_field_timezone_offset($field, $post_id);
+				if (!empty($tz_offset)) {
+					$new += $tz_offset;
+				}
 			}
 
 			$new = apply_filters('cmb_validate_' . $field['type'], $new, $post_id, $field);

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ Custom Metaboxes and Fields (CMB for short) will create metaboxes with custom fi
 * date picker
 * date picker (unix timestamp)
 * date time picker combo (unix timestamp)
+* time zone dropdown
 * time picker
 * color picker
 * textarea


### PR DESCRIPTION
Adds a standalone time zone select dropdown. The time zone select can be used with standalone `text_datetime_timestamp` if desired, which can be useful when multiple datetime fields are used in the same metabox, and they're all in the same timezone. Can be configured like so:

```
array(
    'name' => 'Time zone',
    'desc' => 'Time zone'
    'id'   => $prefix . 'timezone',
    'type' => 'select_timezone',
),
array(
    'name' => __('Start time', 'domain'),
    'desc' => __('Date and time for conference opening', 'domain'),
    'id'   => $prefix . 'start_timestamp',
    'type' => 'text_datetime_timestamp',
    'timezone_meta_key' => $prefix . 'timezone',
),
array(
    'name' => __('End time', 'domain'),
    'desc' => __('Date and time for conference closing', 'domain'),
    'id'   => $prefix . 'end_timestamp',
    'type' => 'text_datetime_timestamp',
    'timezone_meta_key' => $prefix . 'timezone',
),
```
