### PR TITLE
New Example Metabox only added for PHP 5.3+

### DIFF
--- a/init.php
+++ b/init.php
@@ -870,7 +870,7 @@ class cmb_Meta_Box {
 	 * @param  array $field      Field config array
 	 * @return mixed             Possibly validated meta value
 	 */
-	public static function sanitization_cb( $meta_value, $is_saving = false, $field = array() ) {
+	public function sanitization_cb( $meta_value, $is_saving = false, $field = array() ) {
 		if ( empty( $meta_value ) )
 			return $meta_value;
 


### PR DESCRIPTION
In attempt to address #397, I moved the field `text_datetime_timestamp_timezone` out of the general metabox and created a new metabox that is only added if the PHP version is 5.3 or greater.
