### PR TITLE
Added "default" for metaboxes arrays

### DIFF
--- a/init.php
+++ b/init.php
@@ -389,6 +389,9 @@ class cmb_Meta_Box {
 
 			echo empty( $field['before'] ) ? '' : $field['before'];
 
+			if( $field['type'] == 'checkbox' && $field['std'] == 'on' )
+				{ $meta = 'on'; }
+
 			call_user_func( array( $types, $field['type'].$repeatmethod ), $field, $meta, $object_id, $object_type );
 
 			echo empty( $field['after'] ) ? '' : $field['after'];


### PR DESCRIPTION
Added "default" for metaboxes arrays. It works exactly like std, that will replace "default" if it's defined
