### PR TITLE
Prevent escaping issue with WYSIWYG field

### DIFF
--- a/helpers/cmb_Meta_Box_types.php
+++ b/helpers/cmb_Meta_Box_types.php
@@ -412,7 +412,7 @@ class cmb_Meta_Box_types {
 	}
 
 	public static function wysiwyg( $field, $meta ) {
-		wp_editor( self::esc( $meta, 'esc_textarea' ), $field['id'], isset( $field['options'] ) ? $field['options'] : array() );
+		wp_editor( $meta ? $meta : $field['default'], $field['id'], isset( $field['options'] ) ? $field['options'] : array() );
 		echo self::desc( true );
 	}
 


### PR DESCRIPTION
This reverts the previous change. However, there will be a better fix utilising the new escape method.
