### PR TITLE
Prevent missing table styling on new posts

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,11 +9,11 @@ table.cmb_metabox tr:first-of-type td, table.cmb_metabox tr:first-of-type th {
 	border:0;
 }
 
-.post-php table.cmb_metabox td, .post-php table.cmb_metabox th {
+.post-php table.cmb_metabox td, .post-new-php table.cmb_metabox td, .post-php table.cmb_metabox th, .post-new-php table.cmb_metabox th {
 	border-top: 1px solid #E9E9E9;
 }
 
-.post-php table.cmb_metabox th {
+.post-php table.cmb_metabox th, .post-new-php table.cmb_metabox th {
 	text-align: right;
 	font-weight:bold
 }


### PR DESCRIPTION
The body class is different for new posts and so CMB tables are missing some minor styling.
