### PR TITLE
Set correct object_id to be used later on cmb_show_on filter

### DIFF
--- a/init.php
+++ b/init.php
@@ -460,6 +460,7 @@ class cmb_Meta_Box {
 		)
 			return $post_id;
 
+		self::set_object_id( $post_id );
 		self::save_fields( $this->_meta_box, $post_id, 'post' );
 	}
 


### PR DESCRIPTION
This fixes a bug were the post meta doesn't save when using `page-template` on `show_on` filter. This happens when the post id hasn't been saved into object_id since WordPress hasn't set the global post object yet.
