### PR TITLE
Standard Parameter Field for Taxonomy Select Field

### DIFF
--- a/helpers/cmb_Meta_Box_types.php
+++ b/helpers/cmb_Meta_Box_types.php
@@ -421,10 +421,17 @@ class cmb_Meta_Box_types {
 		echo '<select name="', $field['id'], '" id="', $field['id'], '">';
 		$names = wp_get_object_terms( $object_id, $field['taxonomy'] );
 		$terms = get_terms( $field['taxonomy'], 'hide_empty=0' );
+		$taxonomyChosen = false;
+
 		foreach ( $terms as $term ) {
 			if ( !is_wp_error( $names ) && !empty( $names ) && ! strcmp( $term->slug, $names[0]->slug ) ) {
 				echo '<option value="' . $term->slug . '" selected>' . $term->name . '</option>';
-			} else {
+				$taxonomyChosen == true;
+			}
+			else if ( $taxonomyChosen == false && $term->slug == $field['std']) {
+	            echo '<option value="' . $term->slug . '" selected>' . $term->name . '</option>';
+	        }
+			else {
 				echo '<option value="' . $term->slug . '  ' , $meta == $term->slug ? $meta : ' ' ,'  ">' . $term->name . '</option>';
 			}
 		}


### PR DESCRIPTION
Passing a standard value for taxonomy select field using the same ‘std’
field parameter used in the select field.

I know, this code needs improvement.
