### PR TITLE
Horizontal image previews for file_list field

### DIFF
--- a/style.css
+++ b/style.css
@@ -144,7 +144,11 @@ table.cmb_metabox .cmb_media_status {
 }
 
 table.cmb_metabox .cmb_media_status .img_status {
+	clear: none;
+	float: left;
 	display: inline-block;
+	margin-right: 10px;
+	width: auto;
 }
 
 table.cmb_metabox .cmb_media_status .img_status, table.cmb_metabox .cmb_media_status .embed_status {

--- a/style.min.css
+++ b/style.min.css
@@ -9,7 +9,7 @@ table.cmb_metabox input:focus,table.cmb_metabox textarea:focus{background:#fffff
 .cmb-inline ul{padding:4px 0 0 0}.cmb-inline li{display:inline-block;padding-right:18px}table.cmb_metabox input[type="radio"]{margin:0 5px 0 0;padding:0}
 table.cmb_metabox input[type="checkbox"]{margin:0 5px 0 0;padding:0}table.cmb_metabox .mceLayout{border:1px solid #dfdfdf!important}
 table.cmb_metabox .mceIframeContainer{background:#FFF}table.cmb_metabox .meta_mce{width:97%}table.cmb_metabox .meta_mce textarea{width:100%}table.cmb_metabox .cmb_media_status{margin:10px 0 0 0}
-table.cmb_metabox .cmb_media_status .img_status{display:inline-block}table.cmb_metabox .cmb_media_status .img_status,table.cmb_metabox .cmb_media_status .embed_status{position:relative}
+table.cmb_metabox .cmb_media_status .img_status{clear:none;float:left;display:inline-block;margin-right:10px;width:auto}table.cmb_metabox .cmb_media_status .img_status,table.cmb_metabox .cmb_media_status .embed_status{position:relative}
 table.cmb_metabox .cmb_media_status .img_status img,table.cmb_metabox .cmb_media_status .embed_status{border:1px solid #dfdfdf;background:#fafafa;max-width:350px;padding:5px;-moz-border-radius:2px;border-radius:2px}
 table.cmb_metabox .cmb_media_status .embed_status{float:left;max-width:800px}table.cmb_metabox .cmb_media_status .img_status .cmb_remove_file_button,table.cmb_metabox .cmb_media_status .embed_status .cmb_remove_file_button{text-indent:-9999px;background:url(images/ico-delete.png);width:16px;height:16px;position:absolute;top:-5px;left:-5px}
 table.cmb_metabox .attach_list li{clear:both;display:inline-block;margin-bottom:25px;width:100%}table.cmb_metabox .attach_list li img{float:left;margin-right:10px}


### PR DESCRIPTION
Trying to cut down space around image previews by arranging images horizontally instead of vertically.
In situations where user selects a lot of images, vertical preview is not optimal because it wastes a lot of screen real estate.
