### PR TITLE
Metaboxes are initialized too early for some use cases

### DIFF
--- a/init.php
+++ b/init.php
@@ -36,10 +36,16 @@ Version: 		1.0.1
 // Autoload helper classes
 spl_autoload_register('cmb_Meta_Box::autoload_helpers');
 
-$meta_boxes = array();
-$meta_boxes = apply_filters( 'cmb_meta_boxes', $meta_boxes );
-foreach ( $meta_boxes as $meta_box ) {
-	$my_box = new cmb_Meta_Box( $meta_box );
+// Setup metaboxes after WordPress is fully loaded
+add_action('wp_loaded', 'cmb_setup_metaboxes');
+if ( ! function_exists('cmb_setup_metaboxes') ) {
+	function cmb_setup_metaboxes() {
+		$meta_boxes = array();
+		$meta_boxes = apply_filters( 'cmb_meta_boxes', $meta_boxes );
+		foreach ( $meta_boxes as $meta_box ) {
+			$my_box = new cmb_Meta_Box( $meta_box );
+		}
+	}
 }
 
 define( 'CMB_META_BOX_URL', cmb_Meta_Box::get_meta_box_url() );


### PR DESCRIPTION
For my current project, I needed to setup a select that pulls in custom taxonomy terms.  "Use a taxonomy_select" you may rightly say, but for this use case I don't want the term added to the post. I just need it for reference. 

In the process of setting up this select with the tag terms, I used this code:

``` php
        $tags = get_terms( array('shopp_tag') );
        $tag_options = array();

        foreach($tags as $t) {
            $tag_options[] = array('name' => $t->name, 'value' => $t->name);
        }
```

I then setup a new select with the `$tag_options` array:

``` php
                array(
                    'name'     => __( 'Special Tag', 'cmb' ),
                    'desc'     => 'This is a special tag.'
                    'id'       => $this->prefix . 'special_tag',
                    'type'     => 'select',
                    'options' => $tag_options,
                ),
```

However, it didn't work.  When I dug deeper, I realized `get_terms` was returning "Invalid taxonomy" because `cmb_meta_boxes` is called before init, the preferred hook to register taxonomies. 

While this is one use case, I think there are plenty of other potential conflicts here that could be perfectly valid use cases.  A selector that allows you to tie a post type to a page, for example would also fail. 

Given this, I'm suggesting we run the metabox setup on the `wp_loaded` hook.  I've tested this and it's late enough that it works fine, but still early enough it doesn't impact other processes. 

The only thing I haven't tested is metaboxes on the front end.  I don't have any projects that utilize this at the moment. 
