### PR TITLE
fixes for invalid callback on call_user_func and removes extra <

### DIFF
--- a/init.php
+++ b/init.php
@@ -913,7 +913,10 @@ class cmb_Meta_Box {
 		$field['multiple']   = 'multicheck' == $field['type'];
 		$field['repeatable'] = isset( $field['repeatable'] ) && $field['repeatable'];
 		$field['inline']     = isset( $field['inline'] ) && $field['inline'] || false !== stripos( $field['type'], '_inline' );
+
+		return $field;
 	}
+
 
 	/**
 	 * Fills in empty metabox parameters with defaults


### PR DESCRIPTION
self::set_field_defaults( $field ) doesn't return anything so $field['type'] doesn't exists

also removed an extra < that gets rendered
