### PR TITLE
Resolve issue where we only get the first character of the label/value

### DIFF
--- a/helpers/cmb_Meta_Box_types.php
+++ b/helpers/cmb_Meta_Box_types.php
@@ -412,8 +412,8 @@ class cmb_Meta_Box_types {
 		foreach ( $options as $option_key => $option ) {
 
 			// Check for the "old" way
-			$opt_label = isset( $option['name'] ) ? $option['name'] : $option;
-			$opt_value = isset( $option['value'] ) ? $option['value'] : $option_key;
+			$opt_label = is_array( $option ) && array_key_exists( 'name', $option ) ? $option['name'] : $option;
+			$opt_value = is_array( $option ) && array_key_exists( 'value', $option ) ? $option['value'] : $option_key;
 			$selected  = $value == $opt_value;
 
 			if ( ! empty( $args ) ) {


### PR DESCRIPTION
Inconsistent behaviour between PHP versions, see http://stackoverflow.com/a/9132759/2927691.

``` php
$option = 'Boom';
$opt_label = isset( $option['name'] ) ? $option['name'] : $option;
print_r( $opt_label ); // "B" on PHP 5.3, "Boom" on PHP 5.4
```
