### PR TITLE
Repeatable Group Removal Fix

### DIFF
--- a/helpers/cmb_Meta_Box_field.php
+++ b/helpers/cmb_Meta_Box_field.php
@@ -144,7 +144,7 @@ class cmb_Meta_Box_field {
 			? cmb_Meta_Box::get_option( $id, $field_id )
 			: get_metadata( $type, $id, $field_id, ( $single || $repeat ) /* If multicheck this can be multiple values */ );
 
-		if ( $this->group && $this->group->args( 'count' ) > 0 ) {
+		if ( $this->group ) {
 			$data = isset( $data[ $this->group->args( 'count' ) ][ $this->args( '_id' ) ] )
 				? $data[ $this->group->args( 'count' ) ][ $this->args( '_id' ) ]
 				: false;


### PR DESCRIPTION
Issue: Repeatable groups removal

Description: see https://github.com/WebDevStudios/Custom-Metaboxes-and-Fields-for-WordPress/issues/539

Fix: Added JS code to the removeGroupRow function that updates field name attributes so data is not orphaned when a row is removed that's not at the end of the repeatable grouping: https://github.com/DevinWalker/Custom-Metaboxes-and-Fields-for-WordPress/blob/master/js/cmb.js#L418-431

Concerns: if there are a very large number of repeatable field groups the JS could be slow and cause problems. This is because if the user removed the first or second group the code has to go through all the next groups and update the field name attribute. If there are hundreds more... well, that could take a bit.

Also: Reformatted code to WP standards with added spaces, semicolons and what not. 
