### PR TITLE
Adds support for checkbox checked by default

### DIFF
--- a/helpers/cmb_Meta_Box_Sanitize.php
+++ b/helpers/cmb_Meta_Box_Sanitize.php
@@ -82,11 +82,11 @@ class cmb_Meta_Box_Sanitize {
 	/**
 	 * Simple checkbox validation
 	 * @since  1.0.1
-	 * @param  mixed  $val 'on' or false
-	 * @return mixed         'on' or false
+	 * @param  mixed  $val 'on', 'off', or false
+	 * @return mixed         'on', 'off', or false
 	 */
 	public function checkbox( $value ) {
-		return $value === 'on' ? 'on' : false;
+		return $value === 'on' || $value === 'off' ? $value : false;
 	}
 
 	/**

--- a/helpers/cmb_Meta_Box_types.php
+++ b/helpers/cmb_Meta_Box_types.php
@@ -585,10 +585,12 @@ class cmb_Meta_Box_types {
 	public function checkbox() {
 		$meta_value = $this->field->escaped_value();
 		$args = array( 'type' => 'checkbox', 'class' => 'cmb_option cmb_list', 'value' => 'on', 'desc' => '' );
-		if ( ! empty( $meta_value ) ) {
+
+		if ( 'on' == $meta_value ) {
 			$args['checked'] = 'checked';
 		}
-		return sprintf( '%s <label for="%s">%s</label>', $this->input( $args ), $this->_id(), $this->_desc() );
+
+		return sprintf( '<input type="hidden" name="%s" value="off">%s <label for="%s">%s</label>', $this->_name(), $this->input( $args ), $this->_id(), $this->_desc() );
 	}
 
 	public function taxonomy_radio() {


### PR DESCRIPTION
I'd like to suggest this pull request to close #443.

In my testing, the following solution works for single checkboxes as well as checkboxes in repeatable groups.

I attempted to add `'repeatable' => true` to a checkbox to test, but that did not seem to be a valid option for creating repeatable checkboxes.
