### PR TITLE
Adds support for checkbox checked by default

### DIFF
--- a/helpers/cmb_Meta_Box_Sanitize.php
+++ b/helpers/cmb_Meta_Box_Sanitize.php
@@ -96,11 +96,11 @@ class cmb_Meta_Box_Sanitize {
 	/**
 	 * Simple checkbox validation
 	 * @since  1.0.1
-	 * @param  mixed  $val 'on' or false
-	 * @return mixed         'on' or false
+	 * @param  mixed  $val 'on', 'off', or false
+	 * @return mixed       'on', 'off', or false
 	 */
 	public function checkbox( $value ) {
-		return $value === 'on' ? 'on' : false;
+		return $value === 'on' || $value === 'off' ? $value : false;
 	}
 
 	/**

--- a/helpers/cmb_Meta_Box_types.php
+++ b/helpers/cmb_Meta_Box_types.php
@@ -608,10 +608,18 @@ class cmb_Meta_Box_types {
 	public function checkbox() {
 		$meta_value = $this->field->escaped_value();
 		$args = array( 'type' => 'checkbox', 'class' => 'cmb_option cmb_list', 'value' => 'on', 'desc' => '' );
-		if ( ! empty( $meta_value ) ) {
+
+		if ( 'on' == $meta_value ) {
 			$args['checked'] = 'checked';
 		}
-		return sprintf( '%s <label for="%s">%s</label>', $this->input( $args ), $this->_id(), $this->_desc() );
+
+		return sprintf(
+			'<input type="hidden" name="%s" value="off">%s <label for="%s">%s</label>',
+			$this->_name(),
+			$this->input( $args ),
+			$this->_id(),
+			$this->_desc()
+		);
 	}
 
 	public function taxonomy_radio() {


### PR DESCRIPTION
This pull request addresses issue #443, having a checkbox checked by default.

In my testing, this change allows both single checkboxes as well as checkboxes in a repeatable group to be checked by default by adding a `'default' => 'on'` to the CMB field. Example:

```php
array(
    'name' => 'Test Checkbox',
    'desc' => 'field description (optional)',
    'id' => $prefix . 'test_checkbox',
    'type' => 'checkbox',
    'default' => 'on'
),
```

I accomplished this by adding a hidden input with value of "off" and the same name as a checkbox before the checkbox. Thus, when a checkbox is checked, the meta field will now have a value of "on". When the checkbox is not checked, it will have a meta value of "off".