### PR TITLE
Modified get_meta_box_url() to return a protocol agnostic uri

### DIFF
--- a/init.php
+++ b/init.php
@@ -850,7 +850,7 @@ class cmb_Meta_Box {
 			);
 		}
 
-		return trailingslashit( apply_filters('cmb_meta_box_url', $cmb_url ) );
+		return trailingslashit( apply_filters('cmb_meta_box_url', str_replace(array('http://','https://'), '//', $cmb_url) ) );
 	}
 
 	/**


### PR DESCRIPTION
HTTPS environments fail to load the asset on certain browsers due to http:// being a part of the uri. By being protocol agnostic, we play well with all environments.
