### PR TITLE
Fixed regression with "multicheck" fields

### DIFF
--- a/helpers/cmb_Meta_Box_field.php
+++ b/helpers/cmb_Meta_Box_field.php
@@ -447,8 +447,8 @@ class cmb_Meta_Box_field {
 		$args['default']    = apply_filters( 'cmb_default_filter', $args['default'], $args, $this->object_type, $this->object_type );
 		$args['allow']      = 'file' == $args['type'] && ! isset( $args['allow'] ) ? array( 'url', 'attachment' ) : array();
 		$args['save_id']    = 'file' == $args['type'] && ! ( isset( $args['save_id'] ) && ! $args['save_id'] );
-		// $args['multiple']   = isset( $args['multiple'] ) ? $args['multiple'] : ( 'multicheck' == $args['type'] ? true : false );
-		$args['multiple']   = isset( $args['multiple'] ) ? $args['multiple'] : false;
+		$args['multiple']   = isset( $args['multiple'] ) ? $args['multiple'] : ( 'multicheck' == $args['type'] ? true : false );
+		// $args['multiple']   = isset( $args['multiple'] ) ? $args['multiple'] : false;
 		$args['repeatable'] = isset( $args['repeatable'] ) && $args['repeatable'] && ! $this->repeatable_exception( $args['type'] );
 		$args['inline']     = isset( $args['inline'] ) && $args['inline'] || false !== stripos( $args['type'], '_inline' );
 		$args['on_front']   = ! ( isset( $args['on_front'] ) && ! $args['on_front'] );

--- a/init.php
+++ b/init.php
@@ -657,16 +657,15 @@ class cmb_Meta_Box {
 		$name = $field->id();
 		$old  = $field->get_data();
 
-		// if ( $field->args( 'multiple' ) && ! $field->args( 'repeatable' ) && ! $field->group ) {
-		// 	$field->remove_data();
-		// 	if ( ! empty( $new_value ) ) {
-		// 		foreach ( $new_value as $add_new ) {
-		// 			self::$updated[] = $name;
-		// 			$field->update_data( $add_new, $name, false );
-		// 		}
-		// 	}
-		// } else
-		if ( ! empty( $new_value ) && $new_value != $old  ) {
+		 if ( $field->args( 'multiple' ) && ! $field->args( 'repeatable' ) && ! $field->group ) {
+		 	$field->remove_data();
+		 	if ( ! empty( $new_value ) ) {
+		 		foreach ( $new_value as $add_new ) {
+		 			self::$updated[] = $name;
+		 			$field->update_data( $add_new, false );
+		 		}
+		 	}
+		} elseif ( ! empty( $new_value ) && $new_value != $old  ) {
 			self::$updated[] = $name;
 			return $field->update_data( $new_value );
 		} elseif ( empty( $new_value ) ) {


### PR DESCRIPTION
In previous versions, multicheck fields were stored using multiple key/value entries. This was recently changed (maybe due to a bug) so now those fields got saved as serialized arrays. Unfortunately, that change made it impossible to use the "meta_key" and "meta_value" arguments with the get_posts function.
This patch restores the previous behaviour.
