### PR TITLE
Fix open <th> in title of the repeater group

### DIFF
--- a/init.php
+++ b/init.php
@@ -470,7 +470,7 @@ class cmb_Meta_Box {
 					<tr class="cmb-group-title">
 						<th colspan="2">
 							', sprintf( '<h4>%1$s</h4>', $field_group->replace_hash( $field_group->options( 'group_title' ) ) ), '
-						<th>
+						</th>
 					</tr>
 					';
 				}


### PR DESCRIPTION
![captura de tela 2014-09-29 as 14 47 17](https://cloud.githubusercontent.com/assets/4514282/4446260/c24331ae-4800-11e4-8b79-43680f969c38.png)
Error generated a blank space on the right side of the group
