### PR TITLE
Fix taxonomy_radio bug in admin panel display

### DIFF
--- a/helpers/cmb_Meta_Box_types.php
+++ b/helpers/cmb_Meta_Box_types.php
@@ -593,8 +593,11 @@ class cmb_Meta_Box_types {
 
 	public function taxonomy_radio() {
 		$names      = $this->get_object_terms();
-		$saved_term = is_wp_error( $names ) || empty( $names ) ? $this->field->args( 'default' ) : $names[0]->slug;
-		$terms      = get_terms( $this->field->args( 'taxonomy' ), 'hide_empty=0' );
+		$saved_terms   = is_wp_error( $names ) || empty( $names )
+			? $this->field->args( 'default' )
+			: wp_list_pluck( $names, 'slug' );
+		$terms   = get_terms( $this->field->args( 'taxonomy' ), 'hide_empty=0' );
+		$name    = $this->_name() .'[]';
 		$options    = ''; $i = 1;
 
 		if ( ! $terms ) {
@@ -606,7 +609,7 @@ class cmb_Meta_Box_types {
 					'label' => $term->name,
 				);
 
-				if ( $saved_term == $term->slug ) {
+				if (  is_array( $saved_terms ) && in_array( $term->slug, $saved_terms ) ) {
 					$args['checked'] = 'checked';
 				}
 				$options .= $this->list_input( $args, $i );


### PR DESCRIPTION
Fixes `taxonomy_radio` problem at /helpers/cmb_Meta_Box_types.php.

I was getting "Undefined offset: 0 in  /lib/metabox/helpers/cmb_Meta_Box_types.php on line 596" in the admin edit panel. 

I just duplicated the code from `taxonomy_multicheck` to solve it.
