### PR TITLE
Remove beta note for CMB2

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Custom Metaboxes and Fields for WordPress
 
-**Note: all future development will continue on [CMB2](https://github.com/WebDevStudios/CMB2). It is currently in beta testing, so use at your own risk. Backwards compatibility is not guaranteed.**
+**Note: all future development will continue on [CMB2](https://github.com/WebDevStudios/CMB2).**
 
 **Contributors**:
 


### PR DESCRIPTION
http://webdevstudios.com/2015/02/02/cmb2-wordpress-plugin/