### PR TITLE
Fix count

### DIFF
--- a/init.php
+++ b/init.php
@@ -743,7 +743,7 @@ class cmb_Meta_Box {
 		elseif ( is_string( $meta_box['pages'] ) )
 			$type = $meta_box['pages'];
 		// if it's an array of one, extract it
-		elseif ( is_array( $meta_box['pages'] ) && count( $meta_box['pages'] === 1 ) )
+		elseif ( is_array( $meta_box['pages'] ) && count( $meta_box['pages'] ) === 1  )
 			$type = is_string( end( $meta_box['pages'] ) ) ? end( $meta_box['pages'] ) : false;
 
 		if ( !$type )


### PR DESCRIPTION
Fix error on admin screen of WordPress:
```
Warning: count(): Parameter must be an array or an object that implements Countable in /home/clients/d83a962e934c6a3c0f0c51f4da5912d9/web/lecolibry.com/wp-content/themes/wpex-chic/inc/classes/custom-metaboxes/init.php on line 746
```